### PR TITLE
Identity: add initdb config to provide for PostgreSQL

### DIFF
--- a/charts/identity/postgresql-initdb-configmap.yaml
+++ b/charts/identity/postgresql-initdb-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: identity-initdb
+data:
+  identity-cube.sh: |
+    echo "CREATE EXTENSION IF NOT EXISTS CUBE" | postgresql_execute "identity" "postgres" "$POSTGRESQL_POSTGRES_PASSWORD"


### PR DESCRIPTION
To simplify PostgreSQL install this ConfigMap can be provided to the PostgreSQL helm chart to enable necessary Cube extension in the `identity` database on the first boot.