### PR TITLE
Set default security restrictions

### DIFF
--- a/charts/identity/values.yaml
+++ b/charts/identity/values.yaml
@@ -81,3 +81,16 @@ ingress:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+# Default to Pod Security Standard Restricted Profile (https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1002
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL

--- a/charts/processor/values.yaml
+++ b/charts/processor/values.yaml
@@ -84,3 +84,16 @@ ingress:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+
+# Default to Pod Security Standard Restricted Profile (https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1003
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+      - ALL


### PR DESCRIPTION
Some customers are trying to run our containers in hardened configurations. To make it easier for them and as our images don't really require any extended privileges(^) we can just set the default security contexts to most hardened settings by default.

^ Processor TensorRT variant requires root at the moment, but fix should be released soon(?) and the example configuration is targeting OpenVINO at the moment anyway which works fine...


Hardening "verification" can be done with applying https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/security/podsecurity-restricted.yaml to the namespace before installing the charts.